### PR TITLE
Expose tool pose from RT connection in ROS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   trajectory_msgs
   ur_msgs
+  tf
 )
 
 ## System dependencies are found with CMake's conventions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,15 +174,6 @@ target_link_libraries(ur_driver
 ## Install ##
 #############
 
-install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-
-## Mark executables and/or libraries for installation
-install(TARGETS ur_driver ur_hardware_interface
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
 # all install targets should use catkin DESTINATION variables
 # See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,15 @@ target_link_libraries(ur_driver
 ## Install ##
 #############
 
+install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+## Mark executables and/or libraries for installation
+install(TARGETS ur_driver ur_hardware_interface
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
 # all install targets should use catkin DESTINATION variables
 # See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
 

--- a/launch/ur_common.launch
+++ b/launch/ur_common.launch
@@ -12,7 +12,8 @@
   <arg name="min_payload" />
   <arg name="max_payload" />
   <arg name="servoj_time" default="0.008" />
-  
+  <arg name="base_frame"  default="base"/>
+  <arg name="tool_frame"  default="tool0_controller"/>
     
   <!-- The max_velocity parameter is only used for debugging in the ur_driver. It's not related to actual velocity limits -->
   <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
@@ -27,5 +28,7 @@
     <param name="max_payload" type="double" value="$(arg max_payload)" />
     <param name="max_velocity" type="double" value="$(arg max_velocity)" />
     <param name="servoj_time" type="double" value="$(arg servoj_time)" />
+	<param name="base_frame" type="str" value="$(arg base_frame)"/>
+    <param name="tool_frame" type="str" value="$(arg tool_frame)"/>
   </node>
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -50,6 +50,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>trajectory_msgs</build_depend>
   <build_depend>ur_msgs</build_depend>
+  <build_depend>tf</build_depend>
   <run_depend>hardware_interface</run_depend>
   <run_depend>controller_manager</run_depend>
   <run_depend>ros_controllers</run_depend>
@@ -62,6 +63,7 @@
   <run_depend>trajectory_msgs</run_depend>
   <run_depend>ur_msgs</run_depend>
   <run_depend>ur_description</run_depend>
+  <run_depend>tf</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/ur_ros_wrapper.cpp
+++ b/src/ur_ros_wrapper.cpp
@@ -38,6 +38,7 @@
 #include "ur_msgs/Digital.h"
 #include "ur_msgs/Analog.h"
 #include "std_msgs/String.h"
+#include "std_msgs/Int32.h"
 #include <controller_manager/controller_manager.h>
 
 class RosWrapper {
@@ -54,8 +55,8 @@ protected:
 	ros::Subscriber urscript_sub_;
 	ros::ServiceServer io_srv_;
 	ros::ServiceServer payload_srv_;
-	std::thread* rt_publish_thread_;
-	std::thread* mb_publish_thread_;
+    std::thread* rt_publish_thread_;
+    std::thread* mb_publish_thread_;
 	double io_flag_delay_;
 	double max_velocity_;
 	std::vector<double> joint_offsets_;
@@ -423,6 +424,8 @@ private:
 				"joint_states", 1);
 		ros::Publisher wrench_pub = nh_.advertise<geometry_msgs::WrenchStamped>(
 				"wrench", 1);
+        ros::Publisher robot_state_pub = nh_.advertise<std_msgs::Int32>(
+                "ur_driver/robot_state", 1);
 		while (ros::ok()) {
 			sensor_msgs::JointState joint_msg;
 			joint_msg.name = robot_.getJointNames();
@@ -452,6 +455,11 @@ private:
 			wrench_msg.wrench.torque.y = tcp_force[4];
 			wrench_msg.wrench.torque.z = tcp_force[5];
 			wrench_pub.publish(wrench_msg);
+
+            //Publish robot state
+            std_msgs::Int32 robot_state_msg;
+            robot_state_msg.data = (int) robot_.rt_interface_->robot_state_->getRobotMode();
+            robot_state_pub.publish(robot_state_msg);
 
 			robot_.rt_interface_->robot_state_->setDataPublished();
 

--- a/src/ur_ros_wrapper.cpp
+++ b/src/ur_ros_wrapper.cpp
@@ -602,7 +602,11 @@ private:
             double ry = tool_vector_actual[4];
             double rz = tool_vector_actual[5];
             double angle = std::sqrt(std::pow(rx,2) + std::pow(ry,2) + std::pow(rz,2));
-            quat.setRotation(tf::Vector3(rx/angle, ry/angle, rz/angle), angle);
+            if (angle < 1e-16) {
+                quat.setValue(0, 0, 0, 1);
+            } else {
+                quat.setRotation(tf::Vector3(rx/angle, ry/angle, rz/angle), angle);
+            }
 
             //Create and broadcast transform
             tf::Transform transform;

--- a/src/ur_ros_wrapper.cpp
+++ b/src/ur_ros_wrapper.cpp
@@ -509,11 +509,6 @@ private:
 			wrench_msg.wrench.torque.z = tcp_force[5];
 			wrench_pub.publish(wrench_msg);
 
-//            //Publish robot state
-//            std_msgs::Int32 robot_state_msg;
-//            robot_state_msg.data = (int) robot_.rt_interface_->robot_state_->getRobotMode();
-//            robot_state_pub.publish(robot_state_msg);
-
             //Update diagnostics
             driver_status_.robot_mode = static_cast<RobotMode>( robot_.rt_interface_->robot_state_->getRobotMode() );
             driver_status_.safety_mode = static_cast<SafetyMode>( robot_.rt_interface_->robot_state_->getSafety_mode() );

--- a/src/ur_ros_wrapper.cpp
+++ b/src/ur_ros_wrapper.cpp
@@ -618,7 +618,7 @@ private:
             std::vector<double> tcp_speed =
                     robot_.rt_interface_->robot_state_->getTcpSpeedActual();
             geometry_msgs::TwistStamped tool_twist;
-            tool_twist.header.frame_id = tool_frame_;
+            tool_twist.header.frame_id = base_frame_;
             tool_twist.header.stamp = joint_msg.header.stamp;
             tool_twist.twist.linear.x = tcp_speed[0];
             tool_twist.twist.linear.y = tcp_speed[1];

--- a/src/ur_ros_wrapper.cpp
+++ b/src/ur_ros_wrapper.cpp
@@ -39,6 +39,37 @@
 #include "ur_msgs/Analog.h"
 #include "std_msgs/String.h"
 #include <controller_manager/controller_manager.h>
+#include <diagnostic_updater/diagnostic_updater.h>
+#include <diagnostic_updater/publisher.h>
+
+enum RobotMode {
+    ROBOT_MODE_DISCONNECTED,
+    ROBOT_MODE_CONFIRM_SAFETY,
+    ROBOT_MODE_BOOTING,
+    ROBOT_MODE_POWER_OFF,
+    ROBOT_MODE_POWER_ON,
+    ROBOT_MODE_IDLE,
+    ROBOT_MODE_BACKDRIVE,
+    ROBOT_MODE_RUNNING,
+    ROBOT_MODE_UPDATING_FIRMWARE
+};
+
+enum SafetyMode {
+    SAFETY_MODE_NORMAL,
+    SAFETY_MODE_REDUCED,
+    SAFETY_MODE_PROTECTIVE_STOP,
+    SAFETY_MODE_RECOVERY,
+    SAFETY_MODE_SAFEGUARD_STOP,
+    SAFETY_MODE_SYSTEM_EMERGENCY_STOP,
+    SAFETY_MODE_ROBOT_EMERGENCY_STOP,
+    SAFETY_MODE_VIOLATION,
+    SAFETY_MODE_FAULT
+};
+
+struct DriverStatus{
+    RobotMode robot_mode;
+    SafetyMode safety_mode;
+};
 
 class RosWrapper {
 protected:
@@ -54,8 +85,8 @@ protected:
 	ros::Subscriber urscript_sub_;
 	ros::ServiceServer io_srv_;
 	ros::ServiceServer payload_srv_;
-	std::thread* rt_publish_thread_;
-	std::thread* mb_publish_thread_;
+    std::thread* rt_publish_thread_;
+    std::thread* mb_publish_thread_;
 	double io_flag_delay_;
 	double max_velocity_;
 	std::vector<double> joint_offsets_;
@@ -63,6 +94,8 @@ protected:
 	std::thread* ros_control_thread_;
 	boost::shared_ptr<ros_control_ur::UrHardwareInterface> hardware_interface_;
 	boost::shared_ptr<controller_manager::ControllerManager> controller_manager_;
+    diagnostic_updater::Updater updater_;
+    DriverStatus driver_status_;
 
 public:
 	RosWrapper(std::string host) :
@@ -73,6 +106,9 @@ public:
 		std::string joint_prefix = "";
 		std::vector<std::string> joint_names;
 		char buf[256];
+
+        updater_.setHardwareID("ur_driver");
+        updater_.add("Status updater", this, &RosWrapper::driverDiagnostic);
 
 		if (ros::param::get("~prefix", joint_prefix)) {
 			sprintf(buf, "Setting prefix to %s", joint_prefix.c_str());
@@ -170,6 +206,26 @@ public:
 
 	}
 private:
+    void driverDiagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat){
+
+        if (driver_status_.robot_mode == ROBOT_MODE_RUNNING &&
+                (driver_status_.safety_mode == SAFETY_MODE_NORMAL || driver_status_.safety_mode == SAFETY_MODE_REDUCED)){
+            //Robot is running and in normal safety mode
+            stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "Driver OK");
+        }
+        else if (driver_status_.robot_mode == ROBOT_MODE_RUNNING &&
+                 (driver_status_.safety_mode != SAFETY_MODE_NORMAL || driver_status_.safety_mode != SAFETY_MODE_REDUCED)){
+            //Robot is running and in some safety stop
+            stat.summary(diagnostic_msgs::DiagnosticStatus::WARN, "Driver WARNING");
+        }
+        else {
+            //Robot is not running
+            stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR, "Driver ERROR");
+        }
+        stat.add("Robot mode", driver_status_.robot_mode);
+        stat.add("Safety mode", driver_status_.safety_mode);
+    }
+
 	void goalCB() {
 		print_info("on_goal");
 
@@ -452,6 +508,11 @@ private:
 			wrench_msg.wrench.torque.y = tcp_force[4];
 			wrench_msg.wrench.torque.z = tcp_force[5];
 			wrench_pub.publish(wrench_msg);
+
+            //Update diagnostics
+            driver_status_.robot_mode = static_cast<RobotMode>( robot_.rt_interface_->robot_state_->getRobotMode() );
+            driver_status_.safety_mode = static_cast<SafetyMode>( robot_.rt_interface_->robot_state_->getSafety_mode() );
+            updater_.update();
 
 			robot_.rt_interface_->robot_state_->setDataPublished();
 


### PR DESCRIPTION
Solution for issue: https://github.com/ThomasTimm/ur_modern_driver/issues/16

Features:
* Broadcast TF between base and tool as reported by UR controller. This is more accurate than the default pose from URDF model. Default base frame is 'base', tool frame is 'tool0_controller', both can be set using parameters
* Publish the tool velocity as TwistStamped with base frame as reference frame on topic 'tool_velocity'

Notes:
* This was tested in simulation and on real UR5 with version 3.0 and 3.1
* To use 'tool0_controller' as link in URDF, a link with that name should be connected to 'base' by a floating joint and the robot_state_publisher should have this fix: https://github.com/ros/robot_state_publisher/pull/32. This was tested and worked correctly.
