### PR TITLE
Ignore malformed messages from UR5 running 1.8.X.

### DIFF
--- a/src/robot_state_RT.cpp
+++ b/src/robot_state_RT.cpp
@@ -327,6 +327,14 @@ void RobotStateRT::unpack(uint8_t * buf) {
 		val_lock_.unlock();
 		return;
 	}
+	
+	if (version_ > 1.8 & version_ < 1.9 & len != 812) {
+		// In 1.8.14035, every 17th and 18th package is 560 and 9 bytes long/malformed.
+		//printf("Len: %i\n", len);
+		val_lock_.unlock();
+		return;
+	}
+	
 	memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
 	time_ = RobotStateRT::ntohd(unpack_to);
 	offset += sizeof(double);


### PR DESCRIPTION
Fixes #25 
Here, we check if the length of the message is actually 812 bytes long and ignore them if they are not. Every 17th and 18th message is 560 bytes followed by 9 bytes and were interpreted anyway causing the driver to publish corrupted joint states.