### PR TITLE
Remove unused PID gain parameters from controller configuration.

### DIFF
--- a/config/ur10_controllers.yaml
+++ b/config/ur10_controllers.yaml
@@ -45,14 +45,6 @@ pos_based_pos_traj_controller:
    stop_trajectory_duration: 0.5
    state_publish_rate:  125
    action_monitor_rate: 10
-   gains:
-      #!!These values have not been optimized!!
-      shoulder_pan_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
-      shoulder_lift_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
-      elbow_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
-      wrist_1_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
-      wrist_2_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
-      wrist_3_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
 
    # state_publish_rate:  50 # Defaults to 50
    # action_monitor_rate: 20 # Defaults to 20

--- a/config/ur3_controllers.yaml
+++ b/config/ur3_controllers.yaml
@@ -47,14 +47,6 @@ position_based_position_trajectory_controller:
    stop_trajectory_duration: 0.5
    state_publish_rate:  125
    action_monitor_rate: 10
-   gains:
-      #!!These values have not been optimized!!
-      shoulder_pan_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
-      shoulder_lift_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
-      elbow_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
-      wrist_1_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
-      wrist_2_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
-      wrist_3_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
 
    # state_publish_rate:  50 # Defaults to 50
    # action_monitor_rate: 20 # Defaults to 20

--- a/config/ur5_controllers.yaml
+++ b/config/ur5_controllers.yaml
@@ -45,14 +45,6 @@ pos_based_pos_traj_controller:
    stop_trajectory_duration: 0.5
    state_publish_rate:  125
    action_monitor_rate: 10
-   gains:
-      #!!These values have not been optimized!!
-      shoulder_pan_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
-      shoulder_lift_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
-      elbow_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
-      wrist_1_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
-      wrist_2_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
-      wrist_3_joint: {p: 2.0,  i: 0.0, d: 0.01, i_clamp: 1}
 
    # state_publish_rate:  50 # Defaults to 50
    # action_monitor_rate: 20 # Defaults to 20


### PR DESCRIPTION
The `PositionJointInterface`-based version of the `joint_trajectory_controller` does not use a PID, and therefore the gains which are set in the config files are not used at all (see [`HardwareInterfaceAdapter`](https://github.com/ros-controls/ros_controllers/blob/4e08da2fa0711e9c4be776fc1110dab9b5e359aa/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h#L73)).

Removing these gains might avoid [confusing users](https://github.com/ThomasTimm/ur_modern_driver/issues/47#issuecomment-242811317).