### PR TITLE
use std::unique_lock and remove code repetition

### DIFF
--- a/include/ur_modern_driver/robot_state_RT.h
+++ b/include/ur_modern_driver/robot_state_RT.h
@@ -26,12 +26,13 @@
 #include <mutex>
 #include <netinet/in.h>
 #include <condition_variable>
+#include <atomic>
 
 class RobotStateRT {
 private:
-	double version_; //protocol version
+  std::atomic<double> version_; //protocol version
 
-	double time_; //Time elapsed since the controller was started
+  std::atomic<double> time_; //Time elapsed since the controller was started
 	std::vector<double> q_target_; //Target joint positions
 	std::vector<double> qd_target_; //Target joint velocities
 	std::vector<double> qdd_target_; //Target joint accelerations
@@ -48,16 +49,16 @@ private:
 	std::vector<double> tcp_speed_target_; //Target speed of the tool given in Cartesian coordinates
 	std::vector<bool> digital_input_bits_; //Current state of the digital inputs. NOTE: these are bits encoded as int64_t, e.g. a value of 5 corresponds to bit 0 and bit 2 set high
 	std::vector<double> motor_temperatures_; //Temperature of each joint in degrees celsius
-	double controller_timer_; //Controller realtime thread execution time
-	double robot_mode_; //Robot mode
+  std::atomic<double> controller_timer_; //Controller realtime thread execution time
+  std::atomic<double> robot_mode_; //Robot mode
 	std::vector<double> joint_modes_; //Joint control modes
-	double safety_mode_; //Safety mode
+  std::atomic<double> safety_mode_; //Safety mode
 	std::vector<double> tool_accelerometer_values_; //Tool x,y and z accelerometer values (software version 1.7)
-	double speed_scaling_; //Speed scaling of the trajectory limiter
-	double linear_momentum_norm_; //Norm of Cartesian linear momentum
-	double v_main_; //Masterboard: Main voltage
-	double v_robot_; //Matorborad: Robot voltage (48V)
-	double i_robot_; //Masterboard: Robot current
+  std::atomic<double> speed_scaling_; //Speed scaling of the trajectory limiter
+  std::atomic<double> linear_momentum_norm_; //Norm of Cartesian linear momentum
+  std::atomic<double> v_main_; //Masterboard: Main voltage
+  std::atomic<double> v_robot_; //Matorborad: Robot voltage (48V)
+  std::atomic<double> i_robot_; //Masterboard: Robot current
 	std::vector<double> v_actual_; //Actual joint voltages
 
 	std::mutex val_lock_; // Locks the variables while unpack parses data;
@@ -66,8 +67,9 @@ private:
 	bool data_published_; //to avoid spurious wakes
 	bool controller_updated_; //to avoid spurious wakes
 
-	std::vector<double> unpackVector(uint8_t * buf, int start_index,
+  std::vector<double> unpackVector(uint8_t * buf, unsigned int& start_index,
 			int nr_of_vals);
+  double unpackDouble(uint8_t * buf, unsigned int& start_index);
 	std::vector<bool> unpackDigitalInputBits(int64_t data);
 	double ntohd(uint64_t nf);
 

--- a/src/robot_state_RT.cpp
+++ b/src/robot_state_RT.cpp
@@ -18,39 +18,41 @@
 
 #include "ur_modern_driver/robot_state_RT.h"
 
-RobotStateRT::RobotStateRT(std::condition_variable& msg_cond) {
-	version_ = 0.0;
-	time_ = 0.0;
-	q_target_.assign(6, 0.0);
-	qd_target_.assign(6, 0.0);
-	qdd_target_.assign(6, 0.0);
-	i_target_.assign(6, 0.0);
-	m_target_.assign(6, 0.0);
-	q_actual_.assign(6, 0.0);
-	qd_actual_.assign(6, 0.0);
-	i_actual_.assign(6, 0.0);
-	i_control_.assign(6, 0.0);
-	tool_vector_actual_.assign(6, 0.0);
-	tcp_speed_actual_.assign(6, 0.0);
-	tcp_force_.assign(6, 0.0);
-	tool_vector_target_.assign(6, 0.0);
-	tcp_speed_target_.assign(6, 0.0);
-	digital_input_bits_.assign(64, false);
-	motor_temperatures_.assign(6, 0.0);
-	controller_timer_ = 0.0;
-	robot_mode_ = 0.0;
-	joint_modes_.assign(6, 0.0);
-	safety_mode_ = 0.0;
-	tool_accelerometer_values_.assign(3, 0.0);
-	speed_scaling_ = 0.0;
-	linear_momentum_norm_ = 0.0;
-	v_main_ = 0.0;
-	v_robot_ = 0.0;
-	i_robot_ = 0.0;
-	v_actual_.assign(6, 0.0);
-	data_published_ = false;
-	controller_updated_ = false;
-	pMsg_cond_ = &msg_cond;
+RobotStateRT::RobotStateRT(std::condition_variable& msg_cond):
+  version_(0.0),
+  time_(0.0),
+  q_target_(6, 0.0),
+  qd_target_(6, 0.0),
+  qdd_target_(6, 0.0),
+  i_target_(6, 0.0),
+  m_target_(6, 0.0),
+  q_actual_(6, 0.0),
+  qd_actual_(6, 0.0),
+  i_actual_(6, 0.0),
+  i_control_(6, 0.0),
+  tool_vector_actual_(6, 0.0),
+  tcp_speed_actual_(6, 0.0),
+  tcp_force_(6, 0.0),
+  tool_vector_target_(6, 0.0),
+  tcp_speed_target_(6, 0.0),
+  digital_input_bits_(64, false),
+  motor_temperatures_(6, 0.0),
+  controller_timer_(0.0),
+  robot_mode_(0.0),
+  joint_modes_(6, 0.0),
+  safety_mode_(0.0),
+  tool_accelerometer_values_(3, 0.0),
+  speed_scaling_(0.0),
+  linear_momentum_norm_(0.0),
+  v_main_(0.0),
+  v_robot_(0.0),
+  i_robot_(0.0),
+  v_actual_(6, 0.0),
+  data_published_(false),
+  controller_updated_(false),
+  pMsg_cond_(&msg_con)
+{
+
 }
 
 RobotStateRT::~RobotStateRT() {
@@ -74,22 +76,28 @@ bool RobotStateRT::getControllerUpdated() {
 	return controller_updated_;
 }
 
-double RobotStateRT::ntohd(uint64_t nf) {
+inline double RobotStateRT::ntohd(uint64_t nf) {
 	double x;
 	nf = be64toh(nf);
 	memcpy(&x, &nf, sizeof(x));
 	return x;
 }
 
-std::vector<double> RobotStateRT::unpackVector(uint8_t * buf, int start_index,
-		int nr_of_vals) {
-	uint64_t q;
+std::vector<double> RobotStateRT::unpackVector(uint8_t * buf, unsigned int &offset,
+    int nr_of_vals) {
 	std::vector<double> ret;
+  ret.reserve(nr_of_vals);
 	for (int i = 0; i < nr_of_vals; i++) {
-		memcpy(&q, &buf[start_index + i * sizeof(q)], sizeof(q));
-		ret.push_back(ntohd(q));
-	}
+    ret.push_back( unpackDouble( buf, offset));
+  }
 	return ret;
+}
+
+inline double RobotStateRT::unpackDouble(uint8_t * buf, unsigned int &offset) {
+  uint64_t unpack_to;
+  memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
+  offset += sizeof(double);
+  return ntohd(unpack_to);
 }
 
 std::vector<bool> RobotStateRT::unpackDigitalInputBits(int64_t data) {
@@ -101,206 +109,110 @@ std::vector<bool> RobotStateRT::unpackDigitalInputBits(int64_t data) {
 }
 
 void RobotStateRT::setVersion(double ver) {
-	val_lock_.lock();
-	version_ = ver;
-	val_lock_.unlock();
+  version_.store(ver);
 }
 
 double RobotStateRT::getVersion() {
-	double ret;
-	val_lock_.lock();
-	ret = version_;
-	val_lock_.unlock();
-	return ret;
+  return version_.load();
 }
 double RobotStateRT::getTime() {
-	double ret;
-	val_lock_.lock();
-	ret = time_;
-	val_lock_.unlock();
-	return ret;
+  return time_.load();
 }
 std::vector<double> RobotStateRT::getQTarget() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = q_target_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return  q_target_;
 }
 std::vector<double> RobotStateRT::getQdTarget() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = qd_target_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return  qd_target_;
 }
 std::vector<double> RobotStateRT::getQddTarget() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = qdd_target_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return qdd_target_;
 }
 std::vector<double> RobotStateRT::getITarget() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = i_target_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return   i_target_;
 }
 std::vector<double> RobotStateRT::getMTarget() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = m_target_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return   m_target_;
 }
 std::vector<double> RobotStateRT::getQActual() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = q_actual_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return  q_actual_;
 }
 std::vector<double> RobotStateRT::getQdActual() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = qd_actual_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return qd_actual_;
 }
 std::vector<double> RobotStateRT::getIActual() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = i_actual_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return  i_actual_;
 }
 std::vector<double> RobotStateRT::getIControl() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = i_control_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return  i_control_;
 }
 std::vector<double> RobotStateRT::getToolVectorActual() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = tool_vector_actual_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return  tool_vector_actual_;
 }
 std::vector<double> RobotStateRT::getTcpSpeedActual() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = tcp_speed_actual_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return tcp_speed_actual_;
 }
 std::vector<double> RobotStateRT::getTcpForce() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = tcp_force_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return  tcp_force_;
 }
 std::vector<double> RobotStateRT::getToolVectorTarget() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = tool_vector_target_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return  tool_vector_target_;
 }
 std::vector<double> RobotStateRT::getTcpSpeedTarget() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = tcp_speed_target_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return  tcp_speed_target_;
 }
 std::vector<bool> RobotStateRT::getDigitalInputBits() {
-	std::vector<bool> ret;
-	val_lock_.lock();
-	ret = digital_input_bits_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return  digital_input_bits_;
 }
 std::vector<double> RobotStateRT::getMotorTemperatures() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = motor_temperatures_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return  motor_temperatures_;
 }
 double RobotStateRT::getControllerTimer() {
-	double ret;
-	val_lock_.lock();
-	ret = controller_timer_;
-	val_lock_.unlock();
-	return ret;
+  return controller_timer_.load();
 }
 double RobotStateRT::getRobotMode() {
-	double ret;
-	val_lock_.lock();
-	ret = robot_mode_;
-	val_lock_.unlock();
-	return ret;
+  return robot_mode_.load();
 }
 std::vector<double> RobotStateRT::getJointModes() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = joint_modes_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return  joint_modes_;
 }
 double RobotStateRT::getSafety_mode() {
-	double ret;
-	val_lock_.lock();
-	ret = safety_mode_;
-	val_lock_.unlock();
-	return ret;
+  return safety_mode_.load();
 }
 std::vector<double> RobotStateRT::getToolAccelerometerValues() {
-	std::vector<double> ret;
-	val_lock_.lock();
-	ret = tool_accelerometer_values_;
-	val_lock_.unlock();
-	return ret;
+  std::unique_lock lock(val_lock_);
+  return tool_accelerometer_values_;
 }
 double RobotStateRT::getSpeedScaling() {
-	double ret;
-	val_lock_.lock();
-	ret = speed_scaling_;
-	val_lock_.unlock();
-	return ret;
+  return speed_scaling_.load();
 }
 double RobotStateRT::getLinearMomentumNorm() {
-	double ret;
-	val_lock_.lock();
-	ret = linear_momentum_norm_;
-	val_lock_.unlock();
-	return ret;
+  return linear_momentum_norm_.load();
 }
 double RobotStateRT::getVMain() {
-	double ret;
-	val_lock_.lock();
-	ret = v_main_;
-	val_lock_.unlock();
-	return ret;
+  return v_main_.load();
 }
 double RobotStateRT::getVRobot() {
-	double ret;
-	val_lock_.lock();
-	ret = v_robot_;
-	val_lock_.unlock();
-	return ret;
+  return v_robot_.load();
 }
 double RobotStateRT::getIRobot() {
-	double ret;
-	val_lock_.lock();
-	ret = i_robot_;
-	val_lock_.unlock();
-	return ret;
+  return i_robot_.load();
 }
 std::vector<double> RobotStateRT::getVActual() {
 	std::vector<double> ret;
@@ -311,124 +223,96 @@ std::vector<double> RobotStateRT::getVActual() {
 }
 void RobotStateRT::unpack(uint8_t * buf) {
 	int64_t digital_input_bits;
-	uint64_t unpack_to;
-	uint16_t offset = 0;
-	val_lock_.lock();
-	int len;
-	memcpy(&len, &buf[offset], sizeof(len));
+  unsigned offset = 0;
+  {// scope of the lock
+    std::unique_lock lock(val_lock_);
+    int len;
 
-	offset += sizeof(len);
-	len = ntohl(len);
+    memcpy(&len, &buf[offset], sizeof(len));
+    offset += sizeof(len);
+    len = ntohl(len);
 
-	//Check the correct message length is received
-	bool len_good = true;
-	if (version_ >= 1.6 && version_ < 1.7) { //v1.6
-		if (len != 756)
-			len_good = false;
-	} else if (version_ >= 1.7 && version_ < 1.8) { //v1.7
-		if (len != 764)
-			len_good = false;
-	} else if (version_ >= 1.8 && version_ < 1.9) { //v1.8
-		if (len != 812)
-			len_good = false;
-	} else if (version_ >= 3.0 && version_ < 3.2) { //v3.0 & v3.1
-		if (len != 1044)
-			len_good = false;
-	} else if (version_ >= 3.2 && version_ < 3.3) { //v3.2
-		if (len != 1060)
-			len_good = false;
-	}
+    //Check the correct message length is received
+    bool len_good = true;
+    if (version_ >= 1.6 && version_ < 1.7) { //v1.6
+      if (len != 756)
+        len_good = false;
+    } else if (version_ >= 1.7 && version_ < 1.8) { //v1.7
+      if (len != 764)
+        len_good = false;
+    } else if (version_ >= 1.8 && version_ < 1.9) { //v1.8
+      if (len != 812)
+        len_good = false;
+    } else if (version_ >= 3.0 && version_ < 3.2) { //v3.0 & v3.1
+      if (len != 1044)
+        len_good = false;
+    } else if (version_ >= 3.2 && version_ < 3.3) { //v3.2
+      if (len != 1060)
+        len_good = false;
+    }
 
-	if (!len_good) {
-		printf("Wrong length of message on RT interface: %i\n", len);
-		val_lock_.unlock();
-		return;
-	}
+    if (!len_good) {
+      printf("Wrong length of message on RT interface: %i\n", len);
+      return;
+    }
 
-	memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
-	time_ = RobotStateRT::ntohd(unpack_to);
-	offset += sizeof(double);
-	q_target_ = unpackVector(buf, offset, 6);
-	offset += sizeof(double) * 6;
-	qd_target_ = unpackVector(buf, offset, 6);
-	offset += sizeof(double) * 6;
-	qdd_target_ = unpackVector(buf, offset, 6);
-	offset += sizeof(double) * 6;
-	i_target_ = unpackVector(buf, offset, 6);
-	offset += sizeof(double) * 6;
-	m_target_ = unpackVector(buf, offset, 6);
-	offset += sizeof(double) * 6;
-	q_actual_ = unpackVector(buf, offset, 6);
-	offset += sizeof(double) * 6;
-	qd_actual_ = unpackVector(buf, offset, 6);
-	offset += sizeof(double) * 6;
-	i_actual_ = unpackVector(buf, offset, 6);
-	offset += sizeof(double) * 6;
-	if (version_ <= 1.9) {
-		if (version_ > 1.6)
-			tool_accelerometer_values_ = unpackVector(buf, offset, 3);
-		offset += sizeof(double) * (3 + 15);
-		tcp_force_ = unpackVector(buf, offset, 6);
-		offset += sizeof(double) * 6;
-		tool_vector_actual_ = unpackVector(buf, offset, 6);
-		offset += sizeof(double) * 6;
-		tcp_speed_actual_ = unpackVector(buf, offset, 6);
-	} else {
-		i_control_ = unpackVector(buf, offset, 6);
-		offset += sizeof(double) * 6;
-		tool_vector_actual_ = unpackVector(buf, offset, 6);
-		offset += sizeof(double) * 6;
-		tcp_speed_actual_ = unpackVector(buf, offset, 6);
-		offset += sizeof(double) * 6;
-		tcp_force_ = unpackVector(buf, offset, 6);
-		offset += sizeof(double) * 6;
-		tool_vector_target_ = unpackVector(buf, offset, 6);
-		offset += sizeof(double) * 6;
-		tcp_speed_target_ = unpackVector(buf, offset, 6);
-	}
-	offset += sizeof(double) * 6;
+    time_ = unpackDouble(buf, offset);
+    q_target_ = unpackVector(buf, offset, 6);
+    qd_target_ = unpackVector(buf, offset, 6);
+    qdd_target_ = unpackVector(buf, offset, 6);
+    i_target_ = unpackVector(buf, offset, 6);
+    m_target_ = unpackVector(buf, offset, 6);
+    q_actual_ = unpackVector(buf, offset, 6);
+    qd_actual_ = unpackVector(buf, offset, 6);
+    i_actual_ = unpackVector(buf, offset, 6);
+    if (version_ <= 1.9) {
+      if (version_ > 1.6){
+        tool_accelerometer_values_ = unpackVector(buf, offset, 3);
+        offset += sizeof(double) * (15); // TODO: double check that this offset is correct
+      }
+      else{
+        offset += sizeof(double) * (3+15); // TODO: double check that this offset is correct
+      }
+      tcp_force_ = unpackVector(buf, offset, 6);
+      tool_vector_actual_ = unpackVector(buf, offset, 6);
+      tcp_speed_actual_ = unpackVector(buf, offset, 6);
+    } else {
+      i_control_ = unpackVector(buf, offset, 6);
+      tool_vector_actual_ = unpackVector(buf, offset, 6);
+      tcp_speed_actual_ = unpackVector(buf, offset, 6);
+      tcp_force_ = unpackVector(buf, offset, 6);
+      tool_vector_target_ = unpackVector(buf, offset, 6);
+      tcp_speed_target_ = unpackVector(buf, offset, 6);
+    }
 
-	memcpy(&digital_input_bits, &buf[offset], sizeof(digital_input_bits));
-	digital_input_bits_ = unpackDigitalInputBits(be64toh(digital_input_bits));
-	offset += sizeof(double);
-	motor_temperatures_ = unpackVector(buf, offset, 6);
-	offset += sizeof(double) * 6;
-	memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
-	controller_timer_ = ntohd(unpack_to);
-	if (version_ > 1.6) {
-		offset += sizeof(double) * 2;
-		memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
-		robot_mode_ = ntohd(unpack_to);
-		if (version_ > 1.7) {
-			offset += sizeof(double);
-			joint_modes_ = unpackVector(buf, offset, 6);
-		}
-	}
-	if (version_ > 1.8) {
-		offset += sizeof(double) * 6;
-		memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
-		safety_mode_ = ntohd(unpack_to);
-		offset += sizeof(double);
-		tool_accelerometer_values_ = unpackVector(buf, offset, 3);
-		offset += sizeof(double) * 3;
-		memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
-		speed_scaling_ = ntohd(unpack_to);
-		offset += sizeof(double);
-		memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
-		linear_momentum_norm_ = ntohd(unpack_to);
-		offset += sizeof(double);
-		memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
-		v_main_ = ntohd(unpack_to);
-		offset += sizeof(double);
-		memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
-		v_robot_ = ntohd(unpack_to);
-		offset += sizeof(double);
-		memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
-		i_robot_ = ntohd(unpack_to);
-		offset += sizeof(double);
-		v_actual_ = unpackVector(buf, offset, 6);
-	}
-	val_lock_.unlock();
+    memcpy(&digital_input_bits, &buf[offset], sizeof(digital_input_bits));
+    digital_input_bits_ = unpackDigitalInputBits(be64toh(digital_input_bits));
+    offset += sizeof(double);
+    motor_temperatures_ = unpackVector(buf, offset, 6);
+    controller_timer_   = unpackDouble(buf, offset);
+    if (version_ > 1.6) {
+      offset += sizeof(double); // TODO: double check that this offset is correct
+      robot_mode_ = unpackDouble(buf, offset);
+      if (version_ > 1.7) {
+        joint_modes_ = unpackVector(buf, offset, 6);
+      }
+      else{
+        // TODO: double check that this offset is correct
+        offset += sizeof(double) * 6;
+      }
+    }
+    if (version_ > 1.8) {
+      safety_mode_ = unpackDouble(buf, offset);
+      tool_accelerometer_values_ = unpackVector(buf, offset, 3);
+      speed_scaling_ = unpackDouble(buf, offset);
+      linear_momentum_norm_ = unpackDouble(buf, offset);
+      v_main_ = unpackDouble(buf, offset);
+      v_robot_ = unpackDouble(buf, offset);
+      i_robot_ = unpackDouble(buf, offset);
+      v_actual_ = unpackVector(buf, offset, 6);
+    }
+    // lock goes out of scope here
+  }
 	controller_updated_ = true;
 	data_published_ = true;
 	pMsg_cond_->notify_all();


### PR DESCRIPTION
Hi,

this PR should remove some copy and pasting.
It basically:

- use std::unique_lock to write less code (it is also safer than manual lock/unlocks)
- use std::atomic to make the access to some variables easier.

Additionally, I changed the API of unpackVector and added unpackDouble to remove a bunch of copy and paste. In total more than 100 LOC were removed.

In the process of removing this potentially error prone copy-and-paste, I noticed some suspicious branches related to offset and the version number.

I tried hard to keep exactly the same amount of offsets of the original code, but please double check my commens called //TODO


**IMPOTANT: before merging this, it is worth discussing first PR #87, since there might be some conflicts between the two.
If PR#87 is merged, I will take care myself of rebasing and fixing the conflicts.**  

Davide
