### PR TITLE
Use cost references and reserve to avoid memory allocations

### DIFF
--- a/include/ur_modern_driver/do_output.h
+++ b/include/ur_modern_driver/do_output.h
@@ -24,11 +24,11 @@
 #endif
 #include <string>
 
-void print_debug(std::string inp);
-void print_info(std::string inp);
-void print_warning(std::string inp);
-void print_error(std::string inp);
-void print_fatal(std::string inp);
+void print_debug(const std::string& inp);
+void print_info(const std::string &inp);
+void print_warning(const std::string& inp);
+void print_error(const std::string &inp);
+void print_fatal(const std::string& inp);
 
 
 #endif /* UR_DO_OUTPUT_H_ */

--- a/include/ur_modern_driver/do_output.h
+++ b/include/ur_modern_driver/do_output.h
@@ -24,11 +24,17 @@
 #endif
 #include <string>
 
-void print_debug(const std::string& inp);
-void print_info(const std::string &inp);
-void print_warning(const std::string& inp);
-void print_error(const std::string &inp);
-void print_fatal(const std::string& inp);
+void print_debug(const char* inp);
+void print_info(const char* inp);
+void print_warning(const char* inp);
+void print_error(const char* inp);
+void print_fatal(const char* inp);
+
+inline void print_debug(const std::string& inp)   { print_debug(inp.c_str()); }
+inline void print_info(const std::string& inp)    { print_info(inp.c_str()); }
+inline void print_warning(const std::string& inp) { print_warning(inp.c_str()); }
+inline void print_error(const std::string& inp)   { print_error(inp.c_str()); }
+inline void print_fatal(const std::string& inp)   { print_fatal(inp.c_str()); }
 
 
 #endif /* UR_DO_OUTPUT_H_ */

--- a/include/ur_modern_driver/robot_state_RT.h
+++ b/include/ur_modern_driver/robot_state_RT.h
@@ -66,9 +66,9 @@ private:
 	bool data_published_; //to avoid spurious wakes
 	bool controller_updated_; //to avoid spurious wakes
 
-	std::vector<double> unpackVector(uint8_t * buf, int start_index,
-			int nr_of_vals);
-	std::vector<bool> unpackDigitalInputBits(int64_t data);
+  void unpackVector(uint8_t * buf, int start_index,
+      int nr_of_vals, std::vector<double>& output);
+  void unpackDigitalInputBits(int64_t data, std::vector<bool> &output);
 	double ntohd(uint64_t nf);
 
 public:

--- a/include/ur_modern_driver/ur_communication.h
+++ b/include/ur_modern_driver/ur_communication.h
@@ -55,7 +55,7 @@ public:
 	bool connected_;
 	RobotState* robot_state_;
 
-	UrCommunication(std::condition_variable& msg_cond, std::string host);
+  UrCommunication(std::condition_variable& msg_cond, const std::string& host);
 	bool start();
 	void halt();
 

--- a/include/ur_modern_driver/ur_driver.h
+++ b/include/ur_modern_driver/ur_driver.h
@@ -67,23 +67,23 @@ public:
 	void setSpeed(double q0, double q1, double q2, double q3, double q4,
 			double q5, double acc = 100.);
 
-	bool doTraj(std::vector<double> inp_timestamps,
-			std::vector<std::vector<double> > inp_positions,
-			std::vector<std::vector<double> > inp_velocities);
-	void servoj(std::vector<double> positions, int keepalive = 1);
+  bool doTraj(const std::vector<double>& inp_timestamps,
+      const std::vector<std::vector<double> >& inp_positions,
+      const std::vector<std::vector<double> >& inp_velocities);
+  void servoj(const std::vector<double> &positions, int keepalive = 1);
 
 	void stopTraj();
 
 	bool uploadProg();
 	bool openServo();
-	void closeServo(std::vector<double> positions);
+  void closeServo(const std::vector<double> &positions);
 
 	std::vector<double> interp_cubic(double t, double T,
-			std::vector<double> p0_pos, std::vector<double> p1_pos,
-			std::vector<double> p0_vel, std::vector<double> p1_vel);
+      const std::vector<double> p0_pos, const std::vector<double>& p1_pos,
+      const std::vector<double> p0_vel, const std::vector<double>& p1_vel) const;
 
-	std::vector<std::string> getJointNames();
-	void setJointNames(std::vector<std::string> jn);
+  const std::vector<std::string>& getJointNames() const;
+  void setJointNames(const std::vector<std::string>& jn);
 	void setToolVoltage(unsigned int v);
 	void setFlag(unsigned int n, bool b);
 	void setDigitalOut(unsigned int n, bool b);

--- a/include/ur_modern_driver/ur_driver.h
+++ b/include/ur_modern_driver/ur_driver.h
@@ -77,6 +77,7 @@ public:
 	bool uploadProg();
 	bool openServo();
   void closeServo(const std::vector<double> &positions);
+  void closeServo();
 
 	std::vector<double> interp_cubic(double t, double T,
       const std::vector<double> p0_pos, const std::vector<double>& p1_pos,

--- a/include/ur_modern_driver/ur_driver.h
+++ b/include/ur_modern_driver/ur_driver.h
@@ -79,9 +79,10 @@ public:
   void closeServo(const std::vector<double> &positions);
   void closeServo();
 
-	std::vector<double> interp_cubic(double t, double T,
-      const std::vector<double> p0_pos, const std::vector<double>& p1_pos,
-      const std::vector<double> p0_vel, const std::vector<double>& p1_vel) const;
+  static void interp_cubic(double t, double T,
+      const std::vector<double>& p0_pos, const std::vector<double>& p1_pos,
+      const std::vector<double>& p0_vel, const std::vector<double>& p1_vel,
+      std::vector<double> &interpolated_position);
 
   const std::vector<std::string>& getJointNames() const;
   void setJointNames(const std::vector<std::string>& jn);

--- a/include/ur_modern_driver/ur_realtime_communication.h
+++ b/include/ur_modern_driver/ur_realtime_communication.h
@@ -67,9 +67,9 @@ public:
 	void halt();
 	void setSpeed(double q0, double q1, double q2, double q3, double q4,
 			double q5, double acc = 100.);
-	void addCommandToQueue(std::string inp);
+  void addCommandToQueue(std::string inp);
 	void setSafetyCountMax(uint inp);
-	std::string getLocalIp();
+  const std::string &getLocalIp() const;
 
 };
 

--- a/include/ur_modern_driver/ur_realtime_communication.h
+++ b/include/ur_modern_driver/ur_realtime_communication.h
@@ -67,7 +67,8 @@ public:
 	void halt();
 	void setSpeed(double q0, double q1, double q2, double q3, double q4,
 			double q5, double acc = 100.);
-  void addCommandToQueue(std::string inp);
+  void addCommandToQueue(const std::string &inp);
+  void addCommandToQueue(const char* inp);
 	void setSafetyCountMax(uint inp);
   const std::string &getLocalIp() const;
 

--- a/src/do_output.cpp
+++ b/src/do_output.cpp
@@ -18,40 +18,40 @@
 
 #include "ur_modern_driver/do_output.h"
 
-void print_debug(const std::string &inp) {
+void print_debug(const char* inp) {
 #ifdef ROS_BUILD
-	ROS_DEBUG("%s", inp.c_str());
+  ROS_DEBUG("%s", inp);
 #else
-	printf("DEBUG: %s\n", inp.c_str());
+  printf("DEBUG: %s\n", inp);
 #endif
 }
-void print_info(const std::string& inp) {
+void print_info(const char*  inp) {
 #ifdef ROS_BUILD
-	ROS_INFO("%s", inp.c_str());
+  ROS_INFO("%s", inp);
 #else
-	printf("INFO: %s\n", inp.c_str());
+  printf("INFO: %s\n", inp);
 #endif
 }
-void print_warning(const std::string &inp) {
+void print_warning(const char* inp) {
 #ifdef ROS_BUILD
-	ROS_WARN("%s", inp.c_str());
+  ROS_WARN("%s", inp);
 #else
-	printf("WARNING: %s\n", inp.c_str());
+  printf("WARNING: %s\n", inp);
 #endif
 }
-void print_error(const std::string& inp) {
+void print_error(const char* inp) {
 #ifdef ROS_BUILD
-	ROS_ERROR("%s", inp.c_str());
+  ROS_ERROR("%s", inp);
 #else
-	printf("ERROR: %s\n", inp.c_str());
+  printf("ERROR: %s\n", inp);
 #endif
 }
-void print_fatal(const std::string &inp) {
+void print_fatal(const char* inp) {
 #ifdef ROS_BUILD
-	ROS_FATAL("%s", inp.c_str());
+  ROS_FATAL("%s", inp);
 	ros::shutdown();
 #else
-	printf("FATAL: %s\n", inp.c_str());
+  printf("FATAL: %s\n", inp);
 	exit(1);
 #endif
 }

--- a/src/do_output.cpp
+++ b/src/do_output.cpp
@@ -18,35 +18,35 @@
 
 #include "ur_modern_driver/do_output.h"
 
-void print_debug(std::string inp) {
+void print_debug(const std::string &inp) {
 #ifdef ROS_BUILD
 	ROS_DEBUG("%s", inp.c_str());
 #else
 	printf("DEBUG: %s\n", inp.c_str());
 #endif
 }
-void print_info(std::string inp) {
+void print_info(const std::string& inp) {
 #ifdef ROS_BUILD
 	ROS_INFO("%s", inp.c_str());
 #else
 	printf("INFO: %s\n", inp.c_str());
 #endif
 }
-void print_warning(std::string inp) {
+void print_warning(const std::string &inp) {
 #ifdef ROS_BUILD
 	ROS_WARN("%s", inp.c_str());
 #else
 	printf("WARNING: %s\n", inp.c_str());
 #endif
 }
-void print_error(std::string inp) {
+void print_error(const std::string& inp) {
 #ifdef ROS_BUILD
 	ROS_ERROR("%s", inp.c_str());
 #else
 	printf("ERROR: %s\n", inp.c_str());
 #endif
 }
-void print_fatal(std::string inp) {
+void print_fatal(const std::string &inp) {
 #ifdef ROS_BUILD
 	ROS_FATAL("%s", inp.c_str());
 	ros::shutdown();

--- a/src/robot_state_RT.cpp
+++ b/src/robot_state_RT.cpp
@@ -81,23 +81,21 @@ double RobotStateRT::ntohd(uint64_t nf) {
 	return x;
 }
 
-std::vector<double> RobotStateRT::unpackVector(uint8_t * buf, int start_index,
-		int nr_of_vals) {
+void RobotStateRT::unpackVector(uint8_t * buf, int start_index,
+    int nr_of_vals, std::vector<double> &output) {
 	uint64_t q;
-	std::vector<double> ret(nr_of_vals);
+  output.resize(nr_of_vals); // does nothing is the size is already nr_of_vals
 	for (int i = 0; i < nr_of_vals; i++) {
 		memcpy(&q, &buf[start_index + i * sizeof(q)], sizeof(q));
-		ret[i] = (ntohd(q));
+    output[i] = (ntohd(q));
 	}
-	return ret;
 }
 
-std::vector<bool> RobotStateRT::unpackDigitalInputBits(int64_t data) {
-	std::vector<bool> ret(64);
+void RobotStateRT::unpackDigitalInputBits(int64_t data, std::vector<bool>& output) {
+  output.resize(64);
 	for (int i = 0; i < 64; i++) {
-		ret[i] = ((data & (1 << i)) >> i);
+    output[i] = ((data & (1 << i)) >> i);
 	}
-	return ret;
 }
 
 void RobotStateRT::setVersion(double ver) {
@@ -348,50 +346,50 @@ void RobotStateRT::unpack(uint8_t * buf) {
 	memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
 	time_ = RobotStateRT::ntohd(unpack_to);
 	offset += sizeof(double);
-	q_target_ = unpackVector(buf, offset, 6);
+  unpackVector(buf, offset, 6, q_target_);
 	offset += sizeof(double) * 6;
-	qd_target_ = unpackVector(buf, offset, 6);
+  unpackVector(buf, offset, 6, qd_target_);
 	offset += sizeof(double) * 6;
-	qdd_target_ = unpackVector(buf, offset, 6);
+  unpackVector(buf, offset, 6, qdd_target_);
 	offset += sizeof(double) * 6;
-	i_target_ = unpackVector(buf, offset, 6);
+  unpackVector(buf, offset, 6, i_target_);
 	offset += sizeof(double) * 6;
-	m_target_ = unpackVector(buf, offset, 6);
+  unpackVector(buf, offset, 6, m_target_);
 	offset += sizeof(double) * 6;
-	q_actual_ = unpackVector(buf, offset, 6);
+  unpackVector(buf, offset, 6, q_actual_);
 	offset += sizeof(double) * 6;
-	qd_actual_ = unpackVector(buf, offset, 6);
+  unpackVector(buf, offset, 6, qd_actual_);
 	offset += sizeof(double) * 6;
-	i_actual_ = unpackVector(buf, offset, 6);
+  unpackVector(buf, offset, 6, i_actual_);
 	offset += sizeof(double) * 6;
 	if (version_ <= 1.9) {
 		if (version_ > 1.6)
-			tool_accelerometer_values_ = unpackVector(buf, offset, 3);
+      unpackVector(buf, offset, 3, tool_accelerometer_values_);
 		offset += sizeof(double) * (3 + 15);
-		tcp_force_ = unpackVector(buf, offset, 6);
+    unpackVector(buf, offset, 6, tcp_force_);
 		offset += sizeof(double) * 6;
-		tool_vector_actual_ = unpackVector(buf, offset, 6);
+    unpackVector(buf, offset, 6, tool_vector_actual_);
 		offset += sizeof(double) * 6;
-		tcp_speed_actual_ = unpackVector(buf, offset, 6);
+    unpackVector(buf, offset, 6, tcp_speed_actual_);
 	} else {
-		i_control_ = unpackVector(buf, offset, 6);
+    unpackVector(buf, offset, 6, i_control_);
 		offset += sizeof(double) * 6;
-		tool_vector_actual_ = unpackVector(buf, offset, 6);
+    unpackVector(buf, offset, 6, tool_vector_actual_);
 		offset += sizeof(double) * 6;
-		tcp_speed_actual_ = unpackVector(buf, offset, 6);
+    unpackVector(buf, offset, 6, tcp_speed_actual_);
 		offset += sizeof(double) * 6;
-		tcp_force_ = unpackVector(buf, offset, 6);
+    unpackVector(buf, offset, 6, tcp_force_);
 		offset += sizeof(double) * 6;
-		tool_vector_target_ = unpackVector(buf, offset, 6);
+    unpackVector(buf, offset, 6, tool_vector_target_);
 		offset += sizeof(double) * 6;
-		tcp_speed_target_ = unpackVector(buf, offset, 6);
+    unpackVector(buf, offset, 6, tcp_speed_target_);
 	}
 	offset += sizeof(double) * 6;
 	
 	memcpy(&digital_input_bits, &buf[offset], sizeof(digital_input_bits));
-	digital_input_bits_ = unpackDigitalInputBits(be64toh(digital_input_bits));
+  unpackDigitalInputBits(be64toh(digital_input_bits), digital_input_bits_);
 	offset += sizeof(double);
-	motor_temperatures_ = unpackVector(buf, offset, 6);
+  unpackVector(buf, offset, 6, motor_temperatures_);
 	offset += sizeof(double) * 6;
 	memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
 	controller_timer_ = ntohd(unpack_to);
@@ -401,7 +399,7 @@ void RobotStateRT::unpack(uint8_t * buf) {
 		robot_mode_ = ntohd(unpack_to);
 		if (version_ > 1.7) {
 			offset += sizeof(double);
-			joint_modes_ = unpackVector(buf, offset, 6);
+      unpackVector(buf, offset, 6, joint_modes_);
 		}
 	}
 	if (version_ > 1.8) {
@@ -409,7 +407,7 @@ void RobotStateRT::unpack(uint8_t * buf) {
 		memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
 		safety_mode_ = ntohd(unpack_to);
 		offset += sizeof(double);
-		tool_accelerometer_values_ = unpackVector(buf, offset, 3);
+    unpackVector(buf, offset, 3, tool_accelerometer_values_);
 		offset += sizeof(double) * 3;
 		memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
 		speed_scaling_ = ntohd(unpack_to);
@@ -426,7 +424,7 @@ void RobotStateRT::unpack(uint8_t * buf) {
 		memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
 		i_robot_ = ntohd(unpack_to);
 		offset += sizeof(double);
-		v_actual_ = unpackVector(buf, offset, 6);
+    unpackVector(buf, offset, 6, v_actual_);
 	}
 	val_lock_.unlock();
 	controller_updated_ = true;

--- a/src/robot_state_RT.cpp
+++ b/src/robot_state_RT.cpp
@@ -84,18 +84,18 @@ double RobotStateRT::ntohd(uint64_t nf) {
 std::vector<double> RobotStateRT::unpackVector(uint8_t * buf, int start_index,
 		int nr_of_vals) {
 	uint64_t q;
-	std::vector<double> ret;
+	std::vector<double> ret(nr_of_vals);
 	for (int i = 0; i < nr_of_vals; i++) {
 		memcpy(&q, &buf[start_index + i * sizeof(q)], sizeof(q));
-		ret.push_back(ntohd(q));
+		ret[i] = (ntohd(q));
 	}
 	return ret;
 }
 
 std::vector<bool> RobotStateRT::unpackDigitalInputBits(int64_t data) {
-	std::vector<bool> ret;
+	std::vector<bool> ret(64);
 	for (int i = 0; i < 64; i++) {
-		ret.push_back((data & (1 << i)) >> i);
+		ret[i] = ((data & (1 << i)) >> i);
 	}
 	return ret;
 }
@@ -316,10 +316,10 @@ void RobotStateRT::unpack(uint8_t * buf) {
 	val_lock_.lock();
 	int len;
 	memcpy(&len, &buf[offset], sizeof(len));
-
+	
 	offset += sizeof(len);
 	len = ntohl(len);
-
+	
 	//Check the correct message length is received
 	bool len_good = true;
 	if (version_ >= 1.6 && version_ < 1.7) { //v1.6
@@ -338,13 +338,13 @@ void RobotStateRT::unpack(uint8_t * buf) {
 		if (len != 1060)
 			len_good = false;
 	}
-
+	
 	if (!len_good) {
 		printf("Wrong length of message on RT interface: %i\n", len);
 		val_lock_.unlock();
 		return;
 	}
-
+	
 	memcpy(&unpack_to, &buf[offset], sizeof(unpack_to));
 	time_ = RobotStateRT::ntohd(unpack_to);
 	offset += sizeof(double);
@@ -387,7 +387,7 @@ void RobotStateRT::unpack(uint8_t * buf) {
 		tcp_speed_target_ = unpackVector(buf, offset, 6);
 	}
 	offset += sizeof(double) * 6;
-
+	
 	memcpy(&digital_input_bits, &buf[offset], sizeof(digital_input_bits));
 	digital_input_bits_ = unpackDigitalInputBits(be64toh(digital_input_bits));
 	offset += sizeof(double);
@@ -432,6 +432,6 @@ void RobotStateRT::unpack(uint8_t * buf) {
 	controller_updated_ = true;
 	data_published_ = true;
 	pMsg_cond_->notify_all();
-
+	
 }
 

--- a/src/ur_communication.cpp
+++ b/src/ur_communication.cpp
@@ -19,7 +19,7 @@
 #include "ur_modern_driver/ur_communication.h"
 
 UrCommunication::UrCommunication(std::condition_variable& msg_cond,
-		std::string host) {
+    const std::string &host) {
 	robot_state_ = new RobotState(msg_cond);
 	bzero((char *) &pri_serv_addr_, sizeof(pri_serv_addr_));
 	bzero((char *) &sec_serv_addr_, sizeof(sec_serv_addr_));

--- a/src/ur_driver.cpp
+++ b/src/ur_driver.cpp
@@ -59,10 +59,10 @@ UrDriver::UrDriver(std::condition_variable& rt_msg_cond,
 }
 
 std::vector<double> UrDriver::interp_cubic(double t, double T,
-		std::vector<double> p0_pos, std::vector<double> p1_pos,
-		std::vector<double> p0_vel, std::vector<double> p1_vel) {
+    const std::vector<double> p0_pos, const std::vector<double> &p1_pos,
+    const std::vector<double> p0_vel, const std::vector<double> &p1_vel) const {
 	/*Returns positions of the joints at time 't' */
-	std::vector<double> positions;
+  std::vector<double> positions(p0_pos.size());
 	for (unsigned int i = 0; i < p0_pos.size(); i++) {
 		double a = p0_pos[i];
 		double b = p0_vel[i];
@@ -70,14 +70,14 @@ std::vector<double> UrDriver::interp_cubic(double t, double T,
 				- T * p1_vel[i]) / pow(T, 2);
 		double d = (2 * p0_pos[i] - 2 * p1_pos[i] + T * p0_vel[i]
 				+ T * p1_vel[i]) / pow(T, 3);
-		positions.push_back(a + b * t + c * pow(t, 2) + d * pow(t, 3));
+    positions[i] =(a + b * t + c * pow(t, 2) + d * pow(t, 3));
 	}
 	return positions;
 }
 
-bool UrDriver::doTraj(std::vector<double> inp_timestamps,
-		std::vector<std::vector<double> > inp_positions,
-		std::vector<std::vector<double> > inp_velocities) {
+bool UrDriver::doTraj(const std::vector<double> &inp_timestamps,
+    const std::vector<std::vector<double> > &inp_positions,
+    const std::vector<std::vector<double> > &inp_velocities) {
 	std::chrono::high_resolution_clock::time_point t0, t;
 	std::vector<double> positions;
 	unsigned int j;
@@ -115,7 +115,7 @@ bool UrDriver::doTraj(std::vector<double> inp_timestamps,
 	return true;
 }
 
-void UrDriver::servoj(std::vector<double> positions, int keepalive) {
+void UrDriver::servoj(const std::vector<double>& positions, int keepalive) {
 	if (!reverse_connected_) {
 		print_error(
 				"UrDriver::servoj called without a reverse connection present. Keepalive: "
@@ -235,7 +235,7 @@ bool UrDriver::openServo() {
 	reverse_connected_ = true;
 	return true;
 }
-void UrDriver::closeServo(std::vector<double> positions) {
+void UrDriver::closeServo(const std::vector<double>& positions) {
 	if (positions.size() != 6)
 		UrDriver::servoj(rt_interface_->robot_state_->getQActual(), 0);
 	else
@@ -274,11 +274,11 @@ void UrDriver::setSpeed(double q0, double q1, double q2, double q3, double q4,
 	rt_interface_->setSpeed(q0, q1, q2, q3, q4, q5, acc);
 }
 
-std::vector<std::string> UrDriver::getJointNames() {
+const std::vector<std::string> &UrDriver::getJointNames() const {
 	return joint_names_;
 }
 
-void UrDriver::setJointNames(std::vector<std::string> jn) {
+void UrDriver::setJointNames(const std::vector<std::string> &jn) {
 	joint_names_ = jn;
 }
 

--- a/src/ur_driver.cpp
+++ b/src/ur_driver.cpp
@@ -240,7 +240,12 @@ bool UrDriver::openServo() {
 	return true;
 }
 void UrDriver::closeServo(const std::vector<double>& positions) {
-  assert (positions.size() == 6);
+  if (positions.size() != 6);
+  {
+    print_error("Command Rejected: UrDriver::closeServo accepts only vectors with size 6.");
+    closeServo();
+    return;
+  }
   UrDriver::servoj(positions, 0);
 	reverse_connected_ = false;
 	close(new_sockfd_);

--- a/src/ur_driver.cpp
+++ b/src/ur_driver.cpp
@@ -240,13 +240,16 @@ bool UrDriver::openServo() {
 	return true;
 }
 void UrDriver::closeServo(const std::vector<double>& positions) {
-	if (positions.size() != 6)
-		UrDriver::servoj(rt_interface_->robot_state_->getQActual(), 0);
-	else
-		UrDriver::servoj(positions, 0);
-
+  assert (positions.size() == 6);
+  UrDriver::servoj(positions, 0);
 	reverse_connected_ = false;
 	close(new_sockfd_);
+}
+
+void UrDriver::closeServo() {
+  UrDriver::servoj(rt_interface_->robot_state_->getQActual(), 0);
+  reverse_connected_ = false;
+  close(new_sockfd_);
 }
 
 bool UrDriver::start() {

--- a/src/ur_driver.cpp
+++ b/src/ur_driver.cpp
@@ -146,40 +146,42 @@ void UrDriver::stopTraj() {
 }
 
 bool UrDriver::uploadProg() {
-	std::string cmd_str;
+  static std::string cmd_str;
+  cmd_str.clear(); // reuse the memory stored in the previous loop
 	char buf[128];
-	cmd_str = "def driverProg():\n";
+  cmd_str += "def driverProg():\n";
 
 	sprintf(buf, "\tMULT_jointstate = %i\n", MULT_JOINTSTATE_);
 	cmd_str += buf;
 
-	cmd_str += "\tSERVO_IDLE = 0\n";
-	cmd_str += "\tSERVO_RUNNING = 1\n";
-	cmd_str += "\tcmd_servo_state = SERVO_IDLE\n";
-	cmd_str += "\tcmd_servo_q = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]\n";
-	cmd_str += "\tdef set_servo_setpoint(q):\n";
-	cmd_str += "\t\tenter_critical\n";
-	cmd_str += "\t\tcmd_servo_state = SERVO_RUNNING\n";
-	cmd_str += "\t\tcmd_servo_q = q\n";
-	cmd_str += "\t\texit_critical\n";
-	cmd_str += "\tend\n";
-	cmd_str += "\tthread servoThread():\n";
-	cmd_str += "\t\tstate = SERVO_IDLE\n";
-	cmd_str += "\t\twhile True:\n";
-	cmd_str += "\t\t\tenter_critical\n";
-	cmd_str += "\t\t\tq = cmd_servo_q\n";
-	cmd_str += "\t\t\tdo_brake = False\n";
-	cmd_str += "\t\t\tif (state == SERVO_RUNNING) and ";
-	cmd_str += "(cmd_servo_state == SERVO_IDLE):\n";
-	cmd_str += "\t\t\t\tdo_brake = True\n";
-	cmd_str += "\t\t\tend\n";
-	cmd_str += "\t\t\tstate = cmd_servo_state\n";
-	cmd_str += "\t\t\tcmd_servo_state = SERVO_IDLE\n";
-	cmd_str += "\t\t\texit_critical\n";
-	cmd_str += "\t\t\tif do_brake:\n";
-	cmd_str += "\t\t\t\tstopj(1.0)\n";
-	cmd_str += "\t\t\t\tsync()\n";
-	cmd_str += "\t\t\telif state == SERVO_RUNNING:\n";
+  cmd_str +=
+      "\tSERVO_IDLE = 0\n";
+      "\tSERVO_RUNNING = 1\n"
+      "\tcmd_servo_state = SERVO_IDLE\n"
+      "\tcmd_servo_q = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]\n"
+      "\tdef set_servo_setpoint(q):\n"
+      "\t\tenter_critical\n"
+      "\t\tcmd_servo_state = SERVO_RUNNING\n"
+      "\t\tcmd_servo_q = q\n"
+      "\t\texit_critical\n"
+      "\tend\n"
+      "\tthread servoThread():\n"
+      "\t\tstate = SERVO_IDLE\n"
+      "\t\twhile True:\n"
+      "\t\t\tenter_critical\n"
+      "\t\t\tq = cmd_servo_q\n"
+      "\t\t\tdo_brake = False\n"
+      "\t\t\tif (state == SERVO_RUNNING) and "
+      "(cmd_servo_state == SERVO_IDLE):\n"
+      "\t\t\t\tdo_brake = True\n"
+      "\t\t\tend\n"
+      "\t\t\tstate = cmd_servo_state\n"
+      "\t\t\tcmd_servo_state = SERVO_IDLE\n"
+      "\t\t\texit_critical\n"
+      "\t\t\tif do_brake:\n"
+      "\t\t\t\tstopj(1.0)\n"
+      "\t\t\t\tsync()\n"
+      "\t\t\telif state == SERVO_RUNNING:\n";
 
 	if (sec_interface_->robot_state_->getVersion() >= 3.1)
 		sprintf(buf, "\t\t\t\tservoj(q, t=%.4f, lookahead_time=%.4f, gain=%.0f)\n",
@@ -188,35 +190,37 @@ bool UrDriver::uploadProg() {
 		sprintf(buf, "\t\t\t\tservoj(q, t=%.4f)\n", servoj_time_);
 	cmd_str += buf;
 
-	cmd_str += "\t\t\telse:\n";
-	cmd_str += "\t\t\t\tsync()\n";
-	cmd_str += "\t\t\tend\n";
-	cmd_str += "\t\tend\n";
-	cmd_str += "\tend\n";
+  cmd_str +=
+      "\t\t\telse:\n"
+      "\t\t\t\tsync()\n"
+      "\t\t\tend\n"
+      "\t\tend\n"
+      "\tend\n";
 
 	sprintf(buf, "\tsocket_open(\"%s\", %i)\n", ip_addr_.c_str(),
 			REVERSE_PORT_);
 	cmd_str += buf;
 
-	cmd_str += "\tthread_servo = run servoThread()\n";
-	cmd_str += "\tkeepalive = 1\n";
-	cmd_str += "\twhile keepalive > 0:\n";
-	cmd_str += "\t\tparams_mult = socket_read_binary_integer(6+1)\n";
-	cmd_str += "\t\tif params_mult[0] > 0:\n";
-	cmd_str += "\t\t\tq = [params_mult[1] / MULT_jointstate, ";
-	cmd_str += "params_mult[2] / MULT_jointstate, ";
-	cmd_str += "params_mult[3] / MULT_jointstate, ";
-	cmd_str += "params_mult[4] / MULT_jointstate, ";
-	cmd_str += "params_mult[5] / MULT_jointstate, ";
-	cmd_str += "params_mult[6] / MULT_jointstate]\n";
-	cmd_str += "\t\t\tkeepalive = params_mult[7]\n";
-	cmd_str += "\t\t\tset_servo_setpoint(q)\n";
-	cmd_str += "\t\tend\n";
-	cmd_str += "\tend\n";
-	cmd_str += "\tsleep(.1)\n";
-	cmd_str += "\tsocket_close()\n";
-	cmd_str += "\tkill thread_servo\n";
-	cmd_str += "end\n";
+  cmd_str +=
+      "\tthread_servo = run servoThread()\n";
+      "\tkeepalive = 1\n"
+      "\twhile keepalive > 0:\n"
+      "\t\tparams_mult = socket_read_binary_integer(6+1)\n"
+      "\t\tif params_mult[0] > 0:\n"
+      "\t\t\tq = [params_mult[1] / MULT_jointstate, "
+      "params_mult[2] / MULT_jointstate, "
+      "params_mult[3] / MULT_jointstate, "
+      "params_mult[4] / MULT_jointstate, "
+      "params_mult[5] / MULT_jointstate, "
+      "params_mult[6] / MULT_jointstate]\n"
+      "\t\t\tkeepalive = params_mult[7]\n"
+      "\t\t\tset_servo_setpoint(q)\n"
+      "\t\tend\n"
+      "\tend\n"
+      "\tsleep(.1)\n"
+      "\tsocket_close()\n"
+      "\tkill thread_servo\n"
+      "end\n";
 
 	rt_interface_->addCommandToQueue(cmd_str);
 	return UrDriver::openServo();

--- a/src/ur_realtime_communication.cpp
+++ b/src/ur_realtime_communication.cpp
@@ -188,6 +188,6 @@ void UrRealtimeCommunication::setSafetyCountMax(uint inp) {
 	safety_count_max_ = inp;
 }
 
-std::string UrRealtimeCommunication::getLocalIp() {
+const std::string& UrRealtimeCommunication::getLocalIp() const {
 	return local_ip_;
 }

--- a/src/ur_realtime_communication.cpp
+++ b/src/ur_realtime_communication.cpp
@@ -86,7 +86,7 @@ void UrRealtimeCommunication::halt() {
 
 void UrRealtimeCommunication::addCommandToQueue(const std::string& inp) {
 	int bytes_written;
-  assert( inp.back == '\n');
+  assert( inp.back() == '\n');
 	if (connected_)
 		bytes_written = write(sockfd_, inp.c_str(), inp.length());
 	else

--- a/src/ur_realtime_communication.cpp
+++ b/src/ur_realtime_communication.cpp
@@ -84,15 +84,23 @@ void UrRealtimeCommunication::halt() {
 	comThread_.join();
 }
 
-void UrRealtimeCommunication::addCommandToQueue(std::string inp) {
+void UrRealtimeCommunication::addCommandToQueue(const std::string& inp) {
 	int bytes_written;
-	if (inp.back() != '\n') {
-		inp.append("\n");
-	}
+  assert( inp.back == '\n');
 	if (connected_)
 		bytes_written = write(sockfd_, inp.c_str(), inp.length());
 	else
 		print_error("Could not send command \"" +inp + "\". The robot is not connected! Command is discarded" );
+}
+
+void UrRealtimeCommunication::addCommandToQueue(const char* inp) {
+  int bytes_written;
+  const unsigned length = strlen(inp);
+  assert( inp[length-1] == '\n');
+  if (connected_)
+    bytes_written = write(sockfd_, inp, length);
+  else
+    print_error("Could not send command \"" + std::string(inp) + "\". The robot is not connected! Command is discarded" );
 }
 
 void UrRealtimeCommunication::setSpeed(double q0, double q1, double q2,
@@ -108,7 +116,7 @@ void UrRealtimeCommunication::setSpeed(double q0, double q1, double q2,
 				"speedj([%1.5f, %1.5f, %1.5f, %1.5f, %1.5f, %1.5f], %f, 0.02)\n",
 				q0, q1, q2, q3, q4, q5, acc);		
 	}
-	addCommandToQueue((std::string) (cmd));
+  addCommandToQueue(cmd);
 	if (q0 != 0. or q1 != 0. or q2 != 0. or q3 != 0. or q4 != 0. or q5 != 0.) {
 		//If a joint speed is set, make sure we stop it again after some time if the user doesn't
 		safety_count_ = 0;

--- a/src/ur_ros_wrapper.cpp
+++ b/src/ur_ros_wrapper.cpp
@@ -454,7 +454,7 @@ private:
 	
 	void reorder_traj_joints(trajectory_msgs::JointTrajectory& traj) {
 		/* Reorders trajectory - destructive */
-		std::vector<std::string> actual_joint_names = robot_.getJointNames();
+    const std::vector<std::string>& actual_joint_names = robot_.getJointNames();
 		std::vector<unsigned int> mapping;
 		mapping.resize(actual_joint_names.size(), actual_joint_names.size());
 		for (unsigned int i = 0; i < traj.joint_names.size(); i++) {


### PR DESCRIPTION
Hi,

I noticed that the API of many classes do unnecessary copies of std::vectors and std::string.
The cost of copy is relatively small, but the cost of memory allocation is not, especially if you don't need them at all (you don't).
Memory allocation should be avoided in particular in real time systems.

This alternative API should be a drop in replacement for most of the users.

It is also important to make class members const whenever is possible!!
Getters should be const members and return cont references.

Regards

Davide