### PR TITLE
Remove dependecy on ros_controllers metapackage.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.1</version>
   <description>The new driver for the UR3/UR5/UR10 robot arms from universal robots</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="thomas.timm.dk@gmail.com">Thomas Timm Andersen</maintainer>
@@ -54,7 +54,6 @@
   <build_depend>realtime_tools</build_depend>
   <run_depend>hardware_interface</run_depend>
   <run_depend>controller_manager</run_depend>
-  <run_depend>ros_controllers</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>control_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>


### PR DESCRIPTION
As per http://www.ros.org/reps/rep-0127.html, packages are not allowed to
depend on metapackages.