### PR TITLE
Add time parameter back to speedj for SW >= 3.3.

### DIFF
--- a/src/ur_realtime_communication.cpp
+++ b/src/ur_realtime_communication.cpp
@@ -98,7 +98,12 @@ void UrRealtimeCommunication::addCommandToQueue(std::string inp) {
 void UrRealtimeCommunication::setSpeed(double q0, double q1, double q2,
 		double q3, double q4, double q5, double acc) {
 	char cmd[1024];
-	if( robot_state_->getVersion() >= 3.1 ) {
+	if( robot_state_->getVersion() >= 3.3 ) {
+		sprintf(cmd,
+				"speedj([%1.5f, %1.5f, %1.5f, %1.5f, %1.5f, %1.5f], %f, 0.008)\n",
+				q0, q1, q2, q3, q4, q5, acc);
+	}
+	else if( robot_state_->getVersion() >= 3.1 ) {
 		sprintf(cmd,
 				"speedj([%1.5f, %1.5f, %1.5f, %1.5f, %1.5f, %1.5f], %f)\n",
 				q0, q1, q2, q3, q4, q5, acc);


### PR DESCRIPTION
I've been working with a UR with SW version 3.3.4.310 and it turns out that behavior of `speedj` URScript command has changed ([again!](https://github.com/ThomasTimm/ur_modern_driver/issues/55#issuecomment-226141662)) in versions 3.3.1.237 and 3.3.2.266. Search for `speedj` in [these release notes](https://www.universal-robots.com/how-tos-and-faqs/faq/ur-faq/release-note-software-version-33xx/) for more info.

@sergeant-wizard already reported in #92 that the behavior was improved by setting the parameter to `0.008`, so this PR is limited to add yet another version check in `UrRealtimeCommunication::setSpeed` and set `t` differently for SW >= 3.3.

The one thing that still bothers me is that, according to the release notes linked above, the change was introduced in two specific revisions of 3.3.X.X. The new check could be probably be finer grained by leveraging the [SVN revision number](https://github.com/ThomasTimm/ur_modern_driver/blob/9ca88362427e32f8d1a125199f6b8e387e81a711/src/robot_state.cpp#L315). However I really don't have time to dig and find the relation between the X.X specifier in the release notes and the revision number from the robot interface. Anyone willing to work on this?