### PR TITLE
Thread safety

### DIFF
--- a/include/ur_modern_driver/ur_realtime_communication.h
+++ b/include/ur_modern_driver/ur_realtime_communication.h
@@ -60,6 +60,7 @@ private:
 public:
 	bool connected_;
 	RobotStateRT* robot_state_;
+	std::mutex mutex_;
 
 	UrRealtimeCommunication(std::condition_variable& msg_cond, std::string host,
 			unsigned int safety_count_max = 12);

--- a/src/ur_driver.cpp
+++ b/src/ur_driver.cpp
@@ -112,7 +112,11 @@ bool UrDriver::doTraj(std::vector<double> inp_timestamps,
 	executing_traj_ = false;
 	//Signal robot to stop driverProg()
 	UrDriver::closeServo(positions);
-	return true;
+
+	if(inp_timestamps[inp_timestamps.size() - 1] < std::chrono::duration_cast<std::chrono::duration<double>>(t - t0).count())
+		return true;
+	else
+		return false;
 }
 
 void UrDriver::servoj(std::vector<double> positions, int keepalive) {

--- a/src/ur_realtime_communication.cpp
+++ b/src/ur_realtime_communication.cpp
@@ -85,6 +85,8 @@ void UrRealtimeCommunication::halt() {
 }
 
 void UrRealtimeCommunication::addCommandToQueue(std::string inp) {
+	std::unique_lock<std::mutex> lock(mutex_);
+
 	int bytes_written;
 	if (inp.back() != '\n') {
 		inp.append("\n");


### PR DESCRIPTION
This PR addresses some thread safety and race conditions present in the trajectory action server.

The problems/fixes include:
 * `has_goal_` is accessed from `doTraj()` and the action server callbacks, so protect it by a mutex.
 * `goalCB()` and `cancelCB()` also have to be protected against affecting each other, since an async spinner with 3 threads is used - the action server itself does not provide any locking.
 * The `UrRealtimeCommunication` class is not thread-safe. If you call `addCommandToQueue()` from a different thread (e.g. the trajectory thread in `UrDriver::uploadProg()`), you can get data corruption.

There are other subtle changes (joining the trajectory thread properly, ...).

@ThomasTimm, we talked briefly at MBZIRC about your driver. If you want, I can spend some more time on separating the changes so that they are easier for you to check. Does that make sense or will you release your new version soon?